### PR TITLE
Fix typo for websocketaf-async.opam

### DIFF
--- a/websocketaf-async.opam
+++ b/websocketaf-async.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "websocketaf-lwt"
+name: "websocketaf-async"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Antonio N. Monteiro <anmonteiro@gmail.com>" ]
 license: "BSD-3-clause"
@@ -19,4 +19,4 @@ depends: [
   "digestif"
   "base64"
 ]
-synopsis: "Lwt support for websocket/af"
+synopsis: "async support for websocket/af"


### PR DESCRIPTION
Corrects name in websocketaf-async.opam from websocketaf-lwt to websocketaf-async